### PR TITLE
TypeError when passing fields to IndexedObject.loadObjects

### DIFF
--- a/src/patterns/object_store/objects.py
+++ b/src/patterns/object_store/objects.py
@@ -192,7 +192,7 @@ class IndexedObject(Rediston):
         """
         Get all the objects of a given type, with optional paging
         """
-        redisConn = self._getConnection()
+        redisConn = cls._getConnection()
         ids = redisConn.zrange(cls.__classKey(), first, num)
         return cls.loadObjects(ids, redisConn, *fields)
 
@@ -299,12 +299,12 @@ class IndexedObject(Rediston):
         return [(id, newVals[idx]) for idx, id in enumerate(ids)]
 
     @classmethod
-    def updateWhere(condition, **keyValues):
+    def updateWhere(cls, condition, **keyValues):
         """
         Update fields with new values for objects matching a condition
         """
         ids = cls.find(condition)
-        pipe = self._getPipeline('master')
+        pipe = cls._getPipeline('master')
         #update the database
         for id in ids:
             pipe.hmset(cls.__key(id), keyValues)
@@ -313,7 +313,7 @@ class IndexedObject(Rediston):
         res = pipe.execute()
 
         #udpate the keys
-        updateAbleKeys = self.__keySpec.findKeysForUpdate(keyValues.iterkeys())
+        updateAbleKeys = cls.__keySpec.findKeysForUpdate(keyValues.iterkeys())
         for key in updateAbleKeys:
             key.updateMany(((id, keyValues) for ids in ids))
 

--- a/src/patterns/object_store/objects.py
+++ b/src/patterns/object_store/objects.py
@@ -173,6 +173,10 @@ class IndexedObject(Rediston):
         objs = []
         for idx,r in enumerate(ret):
             if r:
+                if fields:
+                    # converting to dict since hmget returns lists
+                    r = dict(zip(fields, r))
+
                 r['id'] = ids[idx]
                 obj = cls( **r)
                 objs.append(obj)


### PR DESCRIPTION
When passing the `fields` parameter is present in `IndexedObject.loadObjects` we use `hmget` instead of `hgetall`.

`hmget` returns `list` instead of `dict` which causes a `TypeError` at line 176 when trying to do: `r['id'] = ids[idx]`.

This patch converts the result `r` to `dict` using the passed fields before continuing.
